### PR TITLE
Calculate gallery size with JS

### DIFF
--- a/input/assets/js/main.js
+++ b/input/assets/js/main.js
@@ -195,9 +195,9 @@ $(".navbar-toggle").click(function() {
 
 // Product gallery - BZoom
 $("ul#bzoom").each(function(index, ul) {
-  $ul = $(ul);
-  var imgCount = $ul.data('count');
-  $ul.zoom({
+  ul = $(ul);
+  var imgCount = ul.find('li.gallery-image').length;
+  ul.zoom({
     zoom_area_width: 300,
     // MORE OPTIONS HERE
     small_thumbs: imgCount,

--- a/input/templates/partials/catalog/product-gallery.hbs
+++ b/input/templates/partials/catalog/product-gallery.hbs
@@ -2,9 +2,9 @@
   <a id="animated-modal-action" class="animated-modal-action" href="#animatedModal">
     <img src="{{@root.meta.assetsPath}}img/zoom-60px.png" width="25" height="25" />
   </a>
-  <ul id="bzoom" data-count="{{gallery.list.length}}">
+  <ul id="bzoom">
     {{#each gallery.list}}
-      <li data-modal-content="{{bigImage}}">
+      <li class="gallery-image" data-modal-content="{{bigImage}}">
         <img class="bzoom_thumb_image" src="{{thumbImage}}">
         <img class="bzoom_big_image" src="{{bigImage}}">
       </li>


### PR DESCRIPTION
For Java, it requires an Array and a attribute resolver to be able to calculate the size. It is easier to calculate the size via JS instead of sending the size via data.